### PR TITLE
Se cambió columna sku de integer a string

### DIFF
--- a/db/migrate/20210817193835_remove_column_sku_to_products.rb
+++ b/db/migrate/20210817193835_remove_column_sku_to_products.rb
@@ -1,0 +1,5 @@
+class RemoveColumnSkuToProducts < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :products, :sku
+  end
+end

--- a/db/migrate/20210817194106_add_column_sku_to_products.rb
+++ b/db/migrate/20210817194106_add_column_sku_to_products.rb
@@ -1,0 +1,5 @@
+class AddColumnSkuToProducts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :products, :sku, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_17_190453) do
+ActiveRecord::Schema.define(version: 2021_08_17_194106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,6 @@ ActiveRecord::Schema.define(version: 2021_08_17_190453) do
     t.integer "old_price"
     t.boolean "active", default: false
     t.boolean "featured", default: false
-    t.integer "sku"
     t.string "unit_type"
     t.integer "quantity_stock"
     t.boolean "discount", default: false
@@ -74,6 +73,7 @@ ActiveRecord::Schema.define(version: 2021_08_17_190453) do
     t.bigint "store_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "sku"
     t.index ["store_id"], name: "index_products_on_store_id"
   end
 


### PR DESCRIPTION
Se cambió columna sku de integer a string, además se realizaron dos migraciones, una para eliminar columna y otra para agregar columna con los cambios requeridos.